### PR TITLE
Sets width to 100% to ensure compatibility across browsers

### DIFF
--- a/src/pages/graph/MainPanel/classes.module.scss
+++ b/src/pages/graph/MainPanel/classes.module.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  width: 100%;
   width: -webkit-fill-available;
   background-color: var(--color-background-main-section);
   padding: 10px;


### PR DESCRIPTION
The `-webkit-fill-available` value for the property `width`, is a WebKit-specific value and is not supported in Firefox. 

To ensure compatibility across all browsers, `width: 100%` is set as a fallback.
.
.

[Screen Recording 2025-01-03 at 12.22.33 AM.webm](https://github.com/user-attachments/assets/4587ba4b-5da4-4608-a756-6b6226f927f3)


