### PR TITLE
fix: 🐛 Sets width to 100% to ensure compatibility across browsers

### DIFF
--- a/src/components/MenuBar/MenuItem/MenuItem.tsx
+++ b/src/components/MenuBar/MenuItem/MenuItem.tsx
@@ -1,8 +1,8 @@
+import Icon from "components/Icon";
 import React, { ReactNode } from "react";
 import Menu from "../Menu";
-import classes from "./classes.module.scss";
 import MenuTrigger from "../MenuTrigger";
-import Icon from "components/Icon";
+import classes from "./classes.module.scss";
 
 type TItem = {
   label: string | ReactNode;
@@ -74,7 +74,7 @@ const MenuItem: React.FC<MenuItemProps> = ({
             display: "flex",
             alignItems: "center",
             columnGap: 8,
-            width: "-webkit-fill-available",
+            width: "100%",
           }}
         >
           {icon}


### PR DESCRIPTION
The `-webkit-fill-available` property is a WebKit-specific value and is not supported in Firefox. 

To ensure compatibility across all browsers `width: 100%` is set inside object literal, replacing `width: -webkit-fill-available.
.
.
[Screen Recording 2025-01-03 at 8.09.53 AM.webm](https://github.com/user-attachments/assets/0db24a21-4609-4c99-91ff-ecc6642cb860)



fixes #33